### PR TITLE
#6 fix url

### DIFF
--- a/Rebus.Events/Rebus.Events.csproj
+++ b/Rebus.Events/Rebus.Events.csproj
@@ -9,7 +9,7 @@
 		<PackageDescription>Simple .NET event listener-based callbacks for common Rebus hooks</PackageDescription>
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus events</PackageTags>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.Events</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #6 